### PR TITLE
Limit number of processes that can be spawned when fetching manifests

### DIFF
--- a/src/edge_containers_cli/cmds/argo_commands.py
+++ b/src/edge_containers_cli/cmds/argo_commands.py
@@ -345,7 +345,8 @@ class ArgoCommands(Commands):
         # 2 is just a backup for if for some reason cpu_count() returns None.
         # 2 would treat it like a dual-core system.
         cpus = os.cpu_count() or 2
-        sem = asyncio.Semaphore(cpus * 5)
+        max_processes = 64
+        sem = asyncio.Semaphore(min(cpus * 5, max_processes))
 
         await self._get_services()
 

--- a/src/edge_containers_cli/cmds/argo_commands.py
+++ b/src/edge_containers_cli/cmds/argo_commands.py
@@ -300,9 +300,9 @@ class ArgoCommands(Commands):
                         f"argocd app manifests {namespace}/{name} --source live",
                     )
 
-                for resource_manifest in mani_resp.split("---")[1:]:
-                    manifest = YAML(typ="safe").load(resource_manifest)
-                    if not manifest:
+                for manifest in YAML(typ="safe").load_all(mani_resp):
+                    if not isinstance(manifest, dict):
+                        continue
                         continue
                     kind = manifest.get("kind")
                     resource_name = manifest.get("metadata", {}).get("name")

--- a/src/edge_containers_cli/cmds/argo_commands.py
+++ b/src/edge_containers_cli/cmds/argo_commands.py
@@ -29,6 +29,8 @@ from edge_containers_cli.logging import log
 from edge_containers_cli.shell import ShellError, shell
 from edge_containers_cli.utils import YamlTypes, _AsyncFuncType, _run_async
 
+sem = asyncio.Semaphore(10)
+
 
 def extract_ns_app(target: str) -> tuple[str, str]:
     namespace, app = target.split("/")
@@ -293,12 +295,16 @@ class ArgoCommands(Commands):
                 except KeyError:
                     label = "service"
 
-                # check if replicas ready
-                mani_resp = await shell.run_command(
-                    f"argocd app manifests {namespace}/{name} --source live",
-                )
-                for manifest in YAML(typ="safe").load_all(mani_resp):
-                    if not isinstance(manifest, dict):
+                # Limit number of processes that can be spawn concurrently
+                async with sem:
+                    # check if replicas ready
+                    mani_resp = await shell.run_command(
+                        f"argocd app manifests {namespace}/{name} --source live",
+                    )
+
+                for resource_manifest in mani_resp.split("---")[1:]:
+                    manifest = YAML(typ="safe").load(resource_manifest)
+                    if not manifest:
                         continue
                     kind = manifest.get("kind")
                     resource_name = manifest.get("metadata", {}).get("name")

--- a/src/edge_containers_cli/cmds/argo_commands.py
+++ b/src/edge_containers_cli/cmds/argo_commands.py
@@ -29,8 +29,6 @@ from edge_containers_cli.logging import log
 from edge_containers_cli.shell import ShellError, shell
 from edge_containers_cli.utils import YamlTypes, _AsyncFuncType, _run_async
 
-sem = asyncio.Semaphore(10)
-
 
 def extract_ns_app(target: str) -> tuple[str, str]:
     namespace, app = target.split("/")
@@ -269,7 +267,7 @@ class ArgoCommands(Commands):
         )
         self.app_dicts = YAML(typ="safe").load(app_resp)
 
-    async def _extract_app_manifests(self, app: dict):
+    async def _extract_app_manifests(self, app: dict, sem: asyncio.Semaphore):
         namespace, _ = extract_ns_app(self.target)
 
         service_data = {
@@ -344,11 +342,16 @@ class ArgoCommands(Commands):
                 self.services_df.extend(service_df)
 
     async def _get_service_data(self):
+        # 2 is just a backup for if for some reason cpu_count() returns None.
+        # 2 would treat it like a dual-core system.
+        cpus = os.cpu_count() or 2
+        sem = asyncio.Semaphore(cpus * 5)
+
         await self._get_services()
 
         async with asyncio.TaskGroup() as group:
             for app in self.app_dicts:
-                group.create_task(self._extract_app_manifests(app))
+                group.create_task(self._extract_app_manifests(app, sem))
 
     def _get_services_df(self, running_only) -> ServicesDataFrame:
         # Clear the current dataframe before polling the current manifests


### PR DESCRIPTION
I noticed when there are a large number of services (e.g. on i19) and the workstation has limited resources, the command can crash as it can't spawn more subprocesses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading application manifests from Argo CD.
  * Reduced failures during large or concurrent manifest retrieval by throttling parallel processing.
  * Enhanced manifest parsing to handle multi-document output more consistently by splitting and parsing each segment individually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->