### PR TITLE
docs: add CLI and environment variable reference pages

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -4,8 +4,9 @@ Technical reference material including APIs and release notes.
 
 ```{toctree}
 :maxdepth: 1
-:glob:
 
+reference/cli
+reference/environment-variables
 API <_api/edge_containers_cli>
 genindex
 Release Notes <https://github.com/epics-containers/edge-containers-cli/releases>

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,258 @@
+# Command line reference
+
+`ec` is a thin wrapper around the tools you would otherwise drive by hand
+(`git`, `kubectl`, `helm`, `argocd`). Every invocation has the form:
+
+```
+$ ec [GLOBAL OPTIONS] COMMAND [ARGS] [COMMAND OPTIONS]
+```
+
+The set of commands and options that `ec` exposes is **not fixed** — it depends
+on the [backend](backends) you select. Commands a backend cannot implement are
+removed from the CLI entirely, and a handful of options are added or removed per
+backend. This page describes the full command surface and notes where it varies.
+
+:::{tip}
+The CLI is self-documenting. `ec --help` lists the commands available for the
+current backend, and `ec COMMAND --help` describes a single command. Because the
+backend is chosen *before* help is rendered, `ec -b K8S --help` and
+`ec -b DEMO --help` show different command lists.
+:::
+
+(global-options)=
+## Global options
+
+Global options come *before* the command. Each one can also be set through an
+[environment variable](environment-variables.md), which is often more convenient
+for values you reuse across every call (such as the repository and target).
+
+| Option | Environment variable | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `--version` | — | — | Print the version of `ec` and exit. |
+| `-r`, `--repo` | `EC_SERVICES_REPO` | *(unset)* | Git repository holding the service instance definitions. |
+| `-t`, `--target` | `EC_TARGET` | *(unset)* | The deployment target: a Kubernetes namespace (K8S) or an `app-namespace/root-app` (ARGOCD). |
+| `-b`, `--backend` | `EC_CLI_BACKEND` | `ARGOCD` | Backend to drive: `ARGOCD`, `K8S` or `DEMO`. |
+| `-v`, `--verbose` | `EC_VERBOSE` | `False` | Print each underlying command before it is run. |
+| `--dryrun` | `EC_DRYRUN` | `False` | Print the underlying commands but do **not** execute them. |
+| `-d`, `--debug` | `EC_DEBUG` | `False` | Enable debug logging and retain temporary working directories. |
+| `--log-level` | `EC_LOG_LEVEL` | `WARNING` | One of `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. |
+| `--log-url` | `EC_LOG_URL` | *(unset)* | Endpoint used by `log-history` to open historical logs. |
+
+:::{note}
+`--repo`, `--target` and `--log-url` have no usable default. A command that
+needs one will fail with a clear message (for example *"Please set `EC_TARGET`
+or pass --target"*) until you provide it. See
+[Environment variables](environment-variables.md) for the recommended way to set
+them once.
+:::
+
+(backends)=
+## Backends
+
+A *backend* determines how `ec` talks to your services. Select one with
+`-b/--backend` or by exporting `EC_CLI_BACKEND`.
+
+| Backend | Drives | Use it when |
+| :--- | :--- | :--- |
+| `ARGOCD` *(default)* | An ArgoCD server that reconciles your services. | Services are managed by ArgoCD (GitOps). |
+| `K8S` | `kubectl` and `helm` directly against a cluster. | You deploy straight to Kubernetes without ArgoCD. |
+| `DEMO` | Built-in sample data — no cluster required. | Trying the tool, demos, and developing the TUI. |
+
+Each backend implements a different slice of the full command set. The next
+section is the authoritative matrix.
+
+## Command availability by backend
+
+Commands fall into three slices:
+
+- a **shared slice** available on every backend,
+- a **deployment slice** (`deploy`, `delete`) available on `ARGOCD` and `K8S`,
+- a **Kubernetes-only slice** for commands that require direct `kubectl`/`helm`
+  access.
+
+| Command | ARGOCD | K8S | DEMO | Summary |
+| :--- | :---: | :---: | :---: | :--- |
+| `env` | ✅ | ✅ | ✅ | List the `EC_*` environment variables and their current values. |
+| `list` | ✅ | ✅ | ✅ | List every service available in the repository. |
+| `instances` | ✅ | ✅ | ✅ | List all versions of one service in the repository. |
+| `ps` | ✅ | ✅ | ✅ | List the services running in the current target. |
+| `monitor` | ✅ | ✅ | ✅ | Open the interactive TUI monitor. |
+| `logs` | ✅ | ✅ | ✅ | Show current (or previous) logs for a service. |
+| `log-history` | ✅ | ✅ | ✅ | Open historical logs for a service. |
+| `restart` | ✅ | ✅ | ✅ | Restart a running service. |
+| `start` | ✅ | ✅ | ✅ | Start a stopped service. |
+| `stop` | ✅ | ✅ | ✅ | Stop a running service. |
+| `deploy` | ✅ | ✅ | — | Deploy a service from its source repository. |
+| `delete` | ✅ | ✅ | — | Remove a service from the target. |
+| `attach` | — | ✅ | — | Attach to the console of a live service. |
+| `exec` | — | ✅ | — | Open a bash prompt inside a running container. |
+| `deploy-local` | — | ✅ | — | Deploy a local helm chart directly, with a dated beta version. |
+| `template` | — | ✅ | — | Render the helm template for a local service definition. |
+
+:::{note}
+A few options also vary by backend:
+- `deploy` drops `--args` and `--wait` on the `ARGOCD` backend (ArgoCD controls
+  rollout and arguments itself).
+- `start` and `stop` drop `--commit`/`--no-commit` on the `K8S` backend (there is
+  no GitOps repository to commit to).
+:::
+
+## Commands
+
+Arguments are positional; options are flags. `SERVICE` below is the name of a
+service and supports shell tab-completion.
+
+### Shared commands
+
+These are available on **all** backends.
+
+#### `ec env`
+
+```
+$ ec env
+```
+
+Print every `EC_*` environment variable `ec` understands and its current value
+(or `Not Defined`). A quick way to confirm your configuration — see
+[Environment variables](environment-variables.md).
+
+#### `ec list`
+
+```
+$ ec list
+```
+
+List every service available in the service repository (`--repo`).
+
+#### `ec instances SERVICE`
+
+```
+$ ec instances SERVICE
+```
+
+List all tagged versions of `SERVICE` found in the repository.
+
+#### `ec ps`
+
+```
+$ ec ps [-r/--running-only]
+```
+
+List the services in the current target as a table. `-r/--running-only`
+restricts the output to services that are currently running.
+
+#### `ec monitor`
+
+```
+$ ec monitor [-r/--running-only]
+```
+
+Open the interactive TUI monitor. `-r/--running-only` starts it showing only
+running services. The monitor can also be served as a web application — see the
+[README](https://github.com/epics-containers/edge-containers-cli#monitor).
+
+#### `ec logs SERVICE`
+
+```
+$ ec logs SERVICE [-p/--previous]
+```
+
+Show the logs for `SERVICE`. `-p/--previous` shows the logs of the previous
+instance instead of the current one.
+
+#### `ec log-history SERVICE`
+
+```
+$ ec log-history SERVICE
+```
+
+Open the historical logs for `SERVICE`. Requires `--log-url`/`EC_LOG_URL`.
+
+#### `ec restart SERVICE`
+
+```
+$ ec restart SERVICE
+```
+
+Restart `SERVICE`.
+
+(ec-start)=
+#### `ec start SERVICE`
+
+```
+$ ec start SERVICE [--commit/--no-commit]
+```
+
+Start `SERVICE`. `--commit` also records the change in the git repository for an
+audit trail (available on `ARGOCD` and `DEMO`; not on `K8S`).
+
+#### `ec stop SERVICE`
+
+```
+$ ec stop SERVICE [--commit/--no-commit]
+```
+
+Stop `SERVICE`. `--commit` behaves as for [`start`](ec-start).
+
+### Deployment commands (ARGOCD and K8S)
+
+#### `ec deploy SERVICE [VERSION]`
+
+```
+$ ec deploy SERVICE [VERSION] [--desc TEXT] [--wait] [-y/--yes] [--args "..."]
+```
+
+Add `SERVICE` to the target from its source repository. `VERSION` defaults to the
+latest tag. Options:
+
+| Option | Description |
+| :--- | :--- |
+| `--desc TEXT` | Custom (kebab-case) description label for the service. |
+| `--wait` | Wait for the service to become ready. *(K8S only — dropped on ARGOCD.)* |
+| `-y`, `--yes` | Skip the confirmation prompt. |
+| `--args "..."` | Extra arguments passed to `helm`/`docker`, quoted. *(K8S only — dropped on ARGOCD.)* |
+
+#### `ec delete SERVICE`
+
+```
+$ ec delete SERVICE [-y/--yes]
+```
+
+Remove `SERVICE` from the target. `-y/--yes` skips the confirmation prompt.
+
+### Kubernetes-only commands (K8S)
+
+#### `ec attach SERVICE`
+
+```
+$ ec attach SERVICE
+```
+
+Attach to the console of a live service.
+
+#### `ec exec SERVICE`
+
+```
+$ ec exec SERVICE
+```
+
+Open an interactive bash prompt inside the running container for `SERVICE`.
+
+#### `ec deploy-local PATH`
+
+```
+$ ec deploy-local PATH [-y/--yes] [--args "..."]
+```
+
+Deploy a local service definition (a helm chart folder) directly to the cluster
+with a dated beta version. `PATH` must be an existing directory. `--args` passes
+extra quoted arguments to `helm`.
+
+#### `ec template PATH`
+
+```
+$ ec template PATH [--args "..."]
+```
+
+Render and print the helm template generated from a local service definition at
+`PATH`. Useful for inspecting what `deploy-local` would apply.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,0 +1,88 @@
+# Environment variables
+
+Every [global option](global-options) of `ec` has an equivalent
+environment variable. Setting them once — in your shell profile, a `.env` file,
+or a Kubernetes/CI environment — saves repeating `--repo`, `--target` and
+`--backend` on every call.
+
+A command-line option always overrides the matching environment variable, which
+in turn overrides the built-in default.
+
+:::{tip}
+Run `ec env` at any time to print every variable below and its current value:
+
+```
+$ ec env
+EC_SERVICES_REPO=https://github.com/my-org/my-beamline-services
+EC_TARGET=Not Defined
+EC_LOGIN=Not Defined
+EC_CLI_BACKEND=K8S
+EC_VERBOSE=Not Defined
+EC_DRYRUN=Not Defined
+EC_DEBUG=Not Defined
+EC_LOG_LEVEL=Not Defined
+EC_LOG_URL=Not Defined
+```
+:::
+
+## Reference
+
+| Variable | Option | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `EC_SERVICES_REPO` | `-r`, `--repo` | *(unset)* | Git repository holding the service instance definitions. |
+| `EC_TARGET` | `-t`, `--target` | *(unset)* | Deployment target: a Kubernetes namespace (`K8S`) or `app-namespace/root-app` (`ARGOCD`). |
+| `EC_CLI_BACKEND` | `-b`, `--backend` | `ARGOCD` | Backend to drive: `ARGOCD`, `K8S` or `DEMO`. |
+| `EC_VERBOSE` | `-v`, `--verbose` | `False` | Print each underlying command before running it. |
+| `EC_DRYRUN` | `--dryrun` | `False` | Print the underlying commands without executing them. |
+| `EC_DEBUG` | `-d`, `--debug` | `False` | Enable debug logging and keep temporary working directories. |
+| `EC_LOG_LEVEL` | `--log-level` | `WARNING` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. |
+| `EC_LOG_URL` | `--log-url` | *(unset)* | Endpoint used by `ec log-history` to open historical logs. |
+| `EC_LOGIN` | *(none)* | *(unset)* | ArgoCD login command — see below. **No command-line equivalent.** |
+
+## Notes on individual variables
+
+### `EC_SERVICES_REPO`
+
+The git repository that defines your services. Required by `list`, `instances`,
+`deploy` and any command that resolves a service version. If unset, those
+commands fail with *"Please set `EC_SERVICES_REPO` or pass --repo"*.
+
+### `EC_TARGET`
+
+Where services are deployed. The meaning depends on the backend:
+
+- **K8S** — the Kubernetes namespace, e.g. `bl01t-iocs`.
+- **ARGOCD** — the ArgoCD application in `app-namespace/root-app` form.
+
+Required by any command that touches the cluster; unset, they fail with
+*"Please set `EC_TARGET` or pass --target"*.
+
+### `EC_CLI_BACKEND`
+
+Chooses the backend (`ARGOCD`, `K8S`, `DEMO`). Because the backend determines
+which commands exist, this also affects `ec --help`. See
+[Backends](backends).
+
+### `EC_LOGIN`
+
+Used only by the `ARGOCD` backend. If `ec` finds the ArgoCD server is
+unauthenticated while validating the target, and `EC_LOGIN` is set, it offers to
+run its value as a login command and then retries — for example:
+
+```
+$ export EC_LOGIN="argocd login my-argocd.example.com --sso"
+```
+
+If `EC_LOGIN` is unset, `ec` instead fails with *"Not authenticated to argocd
+server"*. This variable has **no** command-line flag because it may contain
+credentials; keep it in your environment, not your shell history.
+
+### `EC_VERBOSE`, `EC_DRYRUN`, `EC_DEBUG`
+
+Diagnostic switches. `EC_VERBOSE` echoes each underlying command; `EC_DRYRUN`
+echoes them *without* running anything (useful for learning the equivalent
+`git`/`kubectl`/`helm`/`argocd` invocations); `EC_DEBUG` raises the log level to
+`DEBUG` and retains the temporary working directories `ec` would otherwise clean
+up.
+
+Set any of these to a truthy value (e.g. `1`) to enable.


### PR DESCRIPTION
Adds two reference pages and wires them into the reference toctree:

- **`docs/reference/cli.md`** — full `ec` command line reference, including the shared/backend command slices (which commands and options the ARGOCD/K8S/DEMO backends each expose) and the per-backend option differences.
- **`docs/reference/environment-variables.md`** — reference for all `EC_*` environment variables, their CLI-flag equivalents, defaults, and override precedence.

Built locally with `sphinx-build -W --keep-going` (matching CI's `--fail-on-warning`): no warnings.

Broader doc fill-out (tutorials/how-tos/explanations) is tracked as a nice-to-have in #249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)